### PR TITLE
fix: import & deprecated error

### DIFF
--- a/trajectron/environment/data_structures.py
+++ b/trajectron/environment/data_structures.py
@@ -1,6 +1,7 @@
 import numpy as np
 import pandas as pd
-from collections import Sequence, OrderedDict
+from collections import OrderedDict
+from collections.abc import Sequence
 
 
 class RingBuffer(Sequence):

--- a/trajectron/environment/scene_graph.py
+++ b/trajectron/environment/scene_graph.py
@@ -135,10 +135,10 @@ class TemporalSceneGraph(object):
         position_cube = np.full((total_timesteps, N, 2), np.nan)
 
         adj_cube = np.zeros((total_timesteps, N, N), dtype=np.int8)
-        dist_cube = np.zeros((total_timesteps, N, N), dtype=np.float)
+        dist_cube = np.zeros((total_timesteps, N, N), dtype=np.float64)
 
         node_type_mat = np.zeros((N, N), dtype=np.int8)
-        node_attention_mat = np.zeros((N, N), dtype=np.float)
+        node_attention_mat = np.zeros((N, N), dtype=np.float64)
 
         for node_idx, node in enumerate(nodes):
             if online:


### PR DESCRIPTION
Greetings

This pull fixes the OrderedDict & Sequence import error and np.float deprecated errors in the codebase

Closes #87 